### PR TITLE
IOW-647 change to dynamic db conn info

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -29,17 +29,12 @@ custom:
   vpc:
     securityGroupIds: ${ssm:/iow/retriever-capture/${self:provider.stage}/securityGroupIds~split}
     subnetIds: ${ssm:/iow/aws/vpc/${self:provider.stage}/subnetIds~split}
-  db:
-    connectInfo: ${ssm:/aws/reference/secretsmanager/NWCAPTURE-DB-${self:provider.stage}~true}
+
 functions:
   iowCapture:
     handler: src.load.lambda_handler
     role: arn:aws:iam::${self:custom.accountNumber}:role/csr-Lambda-Role
     environment:
-      DB_HOST: ${self:custom.db.connectInfo.DATABASE_ADDRESS}
-      DB_USER: ${self:custom.db.connectInfo.SCHEMA_OWNER_USERNAME}
-      DB_NAME: ${self:custom.db.connectInfo.DATABASE_NAME}
-      DB_PASSWORD: ${self:custom.db.connectInfo.SCHEMA_OWNER_PASSWORD}
       AWS_DEPLOYMENT_REGION: ${self:provider.region}
       S3_OBJECT_SIZE_LIMIT: 150000000
     vpc: ${self:custom.vpc}

--- a/src/etl/rds.py
+++ b/src/etl/rds.py
@@ -26,7 +26,7 @@ def convert_total_seconds_to_datetime(total_seconds):
 
 class RDS:
 
-    def __init__(self, connect_timeout=65):
+    def __init__(self, db_host, db_user, db_name, db_password, connect_timeout=65):
         """
         connect to the database resource.
 
@@ -34,10 +34,10 @@ class RDS:
 
         """
         self.connection_parameters = {
-            'host': CONFIG['rds']['host'],
-            'database': CONFIG['rds']['database'],
-            'user': CONFIG['rds']['user'],
-            'password': CONFIG['rds']['password'],
+            'host': db_host,
+            'database': db_name,
+            'user': db_user,
+            'password': db_password,
             'connect_timeout': connect_timeout
             # keyword argument from https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-PARAMKEYWORDS
 

--- a/src/etl/test/test_rds.py
+++ b/src/etl/test/test_rds.py
@@ -25,7 +25,7 @@ class TestRDS(TestCase):
     def test_db_connect(self, mock_connection):
         mock_connection.return_value.cursor.return_value = mock.Mock()
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            RDS()
+            RDS(self.host, self.user, self.database, self.password)
             mock_connection.assert_called_with(
                 host='some-host',
                 database='some-database',
@@ -59,35 +59,35 @@ class RdsValidationTests(TestCase):
 
     def test_validate_contains_text(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             rds.validate_contains("Variable", "Contains")
             mock_conn.assert_called_once()
             self.assertTrue(True, "Should not throw exception on a variable that contains text.")
 
     def test_validate_contains_none(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             with self.assertRaises(ValidationException, msg="Should throw exception on a variable that is None."):
                 rds.validate_contains("Variable", None)
                 mock_conn.assert_called_once()
 
     def test_validate_int(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             rds.validate_int("Variable", "100", 100, 200)
             mock_conn.assert_called_once()
             self.assertTrue(True, "Should not throw exception on a variable that is an integer.")
 
     def test_validate_int_float(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             mock_conn.assert_called_once()
             with self.assertRaises(ValidationException,
                                    msg="Should throw exception on a variable that is not an integer."):
                 rds.validate_int("Variable", "100.1", 100, 200)
 
     def test_validate_int_outside_range(self, mock_conn):
-        rds = RDS()
+        rds = RDS(self.host, self.user, self.database, self.password)
         mock_conn.assert_called_once()
         with self.assertRaises(ValidationException,
                                msg="Should throw exception on a variable that is not an integer in range."):
@@ -95,28 +95,28 @@ class RdsValidationTests(TestCase):
 
     def test_validate_api(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             mock_conn.assert_called_once()
             rds.validate_api("api", "https://some.net/api/call")
             self.assertTrue(True, "Should not throw an exception on an API in the URL.")
 
     def test_validate_api_missing(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             mock_conn.assert_called_once()
             with self.assertRaises(ValidationException, msg="Should throw an exception on an API missing in the URL."):
                 rds.validate_api("api", "https://some.net/other/call")
 
     def test_validate_json(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             rds.validate_json("Json Var", '{"json":"value"}')
             mock_conn.assert_called_once()
             self.assertTrue(True, "Should not throw an exception on valid JSON.")
 
     def test_validate_json_invalid(self, mock_conn):
         with mock.patch.dict('src.etl.rds.CONFIG', self.config):
-            rds = RDS()
+            rds = RDS(self.host, self.user, self.database, self.password)
             mock_conn.assert_called_once()
             with self.assertRaises(ValidationException, msg="Should throw an exception on invalid JSON."):
                 rds.validate_json("Json Var", 'not json')


### PR DESCRIPTION
Before making a pull request
----------------------------

- [ ] Make sure all tests run
- [ ] Update the changelog appropriately

Title
-----------
Instead of statically setting up the db connection info in the serverless.yml, retrieve it dynamically with boto3 so we can switch from the test db to the load test db in flight.

Description
-----------
If no JIRA ticket is referenced, describe the changes made. Note anything that you want the reviewers to know while
reviewing your pull request

After making a pull request
---------------------------
- [ ] If appropriate, put the link to the PR in the JIRA ticket
- [ ] Assign someone to review unless the change is trivial
